### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/metatask/__init__.py
+++ b/metatask/__init__.py
@@ -133,7 +133,7 @@ See also: https://docs.python.org/2/library/re.html#module-contents''')
                 c = cmds_config.get(cmd)
                 c["name"] = cmd
                 if c is None:
-                    raise Exception("Missing command '%s' in `cmds`" % cmd)
+                    raise Exception("Missing command '{0!s}' in `cmds`".format(cmd))
                 cmds.append(c)
             else:
                 cmds.append(cmd)
@@ -152,7 +152,7 @@ See also: https://docs.python.org/2/library/re.html#module-contents''')
             else:
                 c = cmds_config.get(cmd)
                 if c is None:
-                    raise Exception("Missing command '%s' in `cmds`" % cmd)
+                    raise Exception("Missing command '{0!s}' in `cmds`".format(cmd))
                 c["name"] = cmd
                 cmds.append(c)
 
@@ -249,7 +249,7 @@ def _process_file(f, args, process, cmds):
         return full_dest, types, messages, metadata
 
     except subprocess.CalledProcessError:
-        sys.stderr.write("Error on getting metadata on '%s'.\n" % f)
+        sys.stderr.write("Error on getting metadata on '{0!s}'.\n".format(f))
 
 
 def init(config_file):

--- a/metatask/process.py
+++ b/metatask/process.py
@@ -19,12 +19,12 @@ def format_num_on_demon(fract):
     if fract == '':
         return ''
     if type(fract) == int:
-        return "%02d" % fract
+        return "{0:02d}".format(fract)
     if type(fract) == dict:
         print(fract)
     s = fract.split("/")
     if len(s) == 1:
-        return "%02d" % int(s[0])
+        return "{0:02d}".format(int(s[0]))
     elif len(s) == 2:
         n, d = s
         return ("%0" + str(len(d)) + "d") % int(n)
@@ -48,7 +48,7 @@ class Process(QObject):
             if isinstance(cmd, str):
                 c = cmds_config.get(cmd)
                 if c is None:
-                    raise Exception("Missing command '%s' in `cmds`" % cmd)
+                    raise Exception("Missing command '{0!s}' in `cmds`".format(cmd))
                 c["name"] = cmd
                 cmds.append(c)
             else:
@@ -97,7 +97,7 @@ class Process(QObject):
                     "^.*{}.*$".format(cmd.get("value_get")),
                     cmd.get("value_format"),
                 )
-                subprocess.check_output(['exiftool', '-%s=%s' % (cmd.get('name'), value), filename])
+                subprocess.check_output(['exiftool', '-{0!s}={1!s}'.format(cmd.get('name'), value), filename])
             else:
                 if 'out_ext' in cmd:
                     out_ext = cmd['out_ext']
@@ -123,15 +123,15 @@ class Process(QObject):
                 # it's a merge
                 if not is_merged and isinstance(filenames, list):
                     params["in"] = " ".join([
-                        "'%s'" % f.replace("'", "'\"'\"'") for f in filenames
+                        "'{0!s}'".format(f.replace("'", "'\"'\"'")) for f in filenames
                     ])
                     # do the merge only one time
                     is_merged = True
                 elif filename is not None:
-                    params["in"] = "'%s'" % filename.replace("'", "'\"'\"'")
+                    params["in"] = "'{0!s}'".format(filename.replace("'", "'\"'\"'"))
 
                 if not inplace:
-                    params["out"] = "'%s'" % out_name.replace("'", "'\"'\"'")
+                    params["out"] = "'{0!s}'".format(out_name.replace("'", "'\"'\"'"))
 
                 try:
                     cmd_cmd = cmd_cmd.format(**params)
@@ -162,7 +162,7 @@ class Process(QObject):
             return content, out_ext
         else:
             if out_ext is not None:
-                destination_filename = "%s.%s" % (re.sub(
+                destination_filename = "{0!s}.{1!s}".format(re.sub(
                     r"\.[a-z0-9A-Z]{2,5}$", "",
                     destination_filename
                 ), out_ext)
@@ -236,7 +236,7 @@ class Process(QObject):
             if isinstance(cmd, str):
                 c = cmds_config.get(cmd)
                 if c is None:
-                    raise Exception("Missing command '%s' in `cmds`" % cmd)
+                    raise Exception("Missing command '{0!s}' in `cmds`".format(cmd))
                 cmds.append(c)
             else:
                 cmds.append(cmd)
@@ -260,7 +260,7 @@ class Process(QObject):
                     "^.*{}.*$".format(cmd.get("value_get")),
                     cmd.get("value_format"),
                 )
-                messages.append("Set the metadata '%s' to '%s'." % (
+                messages.append("Set the metadata '{0!s}' to '{1!s}'.".format(
                     bashcolor.colorize(cmd.get('name'), bashcolor.BLUE),
                     bashcolor.colorize(value, bashcolor.GREEN)
                 ))
@@ -269,7 +269,7 @@ class Process(QObject):
                     extension = cmd['out_ext']
 
         if extension is not None:
-            filename = "%s.%s" % (re.sub(
+            filename = "{0!s}.{1!s}".format(re.sub(
                 r"\.[a-z0-9A-Z]{2,5}$", "",
                 filename
             ), extension)

--- a/metatask/utils.py
+++ b/metatask/utils.py
@@ -46,16 +46,16 @@ def print_diff(str1, str2):
     end = common_start([s[:len(start) - 1:-1] for s in str1], str2[:len(start) - 1:-1])[::-1]
 
     for s in str1:
-        print("- %s" % colorize("%s%s%s" % (
+        print("- {0!s}".format(colorize("{0!s}{1!s}{2!s}".format(
             start,
             colorize(different(s, start, end), effects=[INVERSE]),
-            end,
-        ), RED))
-    print("+ %s" % colorize("%s%s%s" % (
+            end
+        ), RED)))
+    print("+ {0!s}".format(colorize("{0!s}{1!s}{2!s}".format(
         start,
         colorize(different(str2, start, end), effects=[INVERSE]),
-        end,
-    ), GREEN))
+        end
+    ), GREEN)))
 
 
 def split(path):
@@ -122,9 +122,9 @@ def confirm(prompt=None, resp=False):
         prompt = "Confirm"
 
     if resp:
-        prompt = "%s [%s]|%s: " % (prompt, "y", "n")
+        prompt = "{0!s} [{1!s}]|{2!s}: ".format(prompt, "y", "n")
     else:
-        prompt = "%s [%s]|%s: " % (prompt, "n", "y")
+        prompt = "{0!s} [{1!s}]|{2!s}: ".format(prompt, "n", "y")
 
     while True:
         ans = input(prompt)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:sbrunner:metatask?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:sbrunner:metatask?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)